### PR TITLE
Fix RuntimeError from redundant close() in /video WebSocket handler

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -58,7 +58,7 @@ async def handle_ws(websocket: WebSocket):
                 await websocket.send_bytes(frame_bytes)
                 await asyncio.sleep(0.1)
     except WebSocketDisconnect:
-        await websocket.close()
+        pass
 
 
 @app.get('/teleop/startup')


### PR DESCRIPTION
Remove redundant `websocket.close()` in the `WebSocketDisconnect` except block. The second close threw `RuntimeError` because the connection was already closed. This fired on every React `useEffect` cleanup, so the server threw this traceback constantly during normal teleop use.

 Closes #18
 Closes #35